### PR TITLE
add npm import to vue-dynamic-import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,9 @@ Webpack plugin, `BabelMultiTargetPlugin`.
 
 [![NPM](https://nodei.co/npm/webpack-babel-multi-target-plugin.png)](https://npmjs.org/package/webpack-babel-multi-target-plugin)
 
-Using the plugin requires make a few small changes to your existing webpack configuration:
+Using the plugin requires making a few small changes to your existing webpack configuration:
 
 * Replace any instances of `babel-loader` with `BabelMultiTargetPlugin.loader()`
-
-* TypeScript
-  * Loader rules must use `BabelMultiTargetPlugin.loader()` after your compiler loader (remember, loaders are run bottom to top)
-  * Set `tsconfig` to `target` es6 or higher
-
-* Vue
-  * Replace `'vue-loader'` with `BabelMultiTargetPlugin.loader('vue-loader')`
 
 * Set `resolve.mainFields` to include `es2015`, which allows webpack to
 load the es2015 modules if a package provides them according to the
@@ -32,6 +25,13 @@ other package standards.
 be customized (see below)
 
 * Remove any `.babelrc` - see "Options Reference" below for setting preset options
+
+* TypeScript
+  * Loader rules must use `BabelMultiTargetPlugin.loader()` after your compiler loader (remember, loaders are run bottom to top)
+  * Set `tsconfig` to `target` es6 or higher
+
+* Vue
+  * Replace `'vue-loader'` with `BabelMultiTargetPlugin.loader('vue-loader')`
 
 ## Configuration Defaults
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ other package standards.
  configuration's `plugins` property
 
 * `BabelMultiTargetPlugin` does not require any configuration - but can
-be customized (see below)
+be customized (see [Options Reference](#options-reference) below)
 
-* Remove any `.babelrc` - see "Options Reference" below for setting preset options
+* Remove any `.babelrc` - see [Options Reference](#options-reference) below for setting preset options
 
 * TypeScript
   * Loader rules must use `BabelMultiTargetPlugin.loader()` after your compiler loader (remember, loaders are run bottom to top)
@@ -61,12 +61,12 @@ versions that don't support `<script type="module">`
   * Default: `{ modules: false, useBuiltIns: 'usage' }`
   * **IMPORTANT:** `modules` is forced to `false` to avoid problems with transformed commonjs modules
 * **`doNotTarget`** (`RegExp[]`) - an array of `RegExp` patterns for modules which
- will be excluded from targeting (see "How It Works" below)
+ will be excluded from targeting (see [How It Works](#how-it-works) below)
 * **`exclude`** (`RegExp[]`) - an array of `RegExp` patterns for modules which will
  be excluded from transpiling
 * **`targets`** (`{ [browserProfile: string]: BabelTargetOptions }`) - a
  map of browser profiles to target definitions. This is used to control
- the transpilation for each browser target. See "Configuration Defaults"
+ the transpilation for each browser target. See [Configuration Defaults](#configuration-defaults)
  above for default values.
   * **`targets[browserProfile].key`** (`string`) - Used internally to
   identify the target, and is appended to the filename of an asset if

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Webpack plugin, `BabelMultiTargetPlugin`.
 
 Using the plugin requires making a few small changes to your existing webpack configuration:
 
-* Replace any instances of `babel-loader` with `BabelMultiTargetPlugin.loader()`
+* Replace any instances of `'babel-loader'` with `BabelMultiTargetPlugin.loader()`
+  * Do not use a `Loader` configuration object here - see [Options Reference](#options-reference)
+  below for information on customizing options for `'babel-loader'`
 
 * Set `resolve.mainFields` to include `es2015`, which allows webpack to
 load the es2015 modules if a package provides them according to the

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ be customized (see below)
 * Vue
   * Replace `'vue-loader'` with `BabelMultiTargetPlugin.loader('vue-loader')`
 
+## Upgrading from v1.x
+
+* Change usages of `BabelMultiTargetPlugin.loader` to `BabelMultiTargetPlugin.loader()`
+
 ## Configuration Defaults
 
 `BabelMultiTargetPlugin` does not require any options to be set. The

--- a/README.md
+++ b/README.md
@@ -308,6 +308,17 @@ of ES supported level). If [HtmlWebpackPlugin](https://github.com/jantimon/html-
 is being used, the script tags are updated to use the appropriate
 `type="module"` and `nomodule` attributes.
 
+### Blind Targeting
+In some circumstances, such as lazy-loaded routes and modules with
+Angular, Vue, and ES6 dynamic imports, it may not be possible to
+determine the entry point of a module. In these cases, the plugin will
+assign the module a target on its own. It does this by creating an array
+of the targets, and removing and assigning one target each time it
+encounters a given resource.
+
+If you encounter a `BlindTargetingError` while attempting to use this
+plugin, please create an issue with a simple reproduction.
+
 ## Benefits
 
 * Automatically sets up your index HTML files with both "modern" and

--- a/examples/vue-dynamic-import/README.md
+++ b/examples/vue-dynamic-import/README.md
@@ -1,0 +1,1 @@
+# Example: mixing vue-loader and dynamic imports

--- a/examples/vue-dynamic-import/package-lock.json
+++ b/examples/vue-dynamic-import/package-lock.json
@@ -1,0 +1,526 @@
+{
+  "name": "webpack-bable-multi-target-plugin-examples-vue-dynamic-import",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@vue/component-compiler-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.2.0.tgz",
+      "integrity": "sha512-pS4zlcdD7BvedyB+IfiTfrbi6C977UMIfulSk8r6uL0BU46ZE2+fUj/zbSNSfVxeaj9ElmnSni5OMwF9np+b+w==",
+      "dev": true,
+      "requires": {
+        "consolidate": "^0.15.1",
+        "hash-sum": "^1.0.2",
+        "lru-cache": "^4.1.2",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^6.0.20",
+        "postcss-selector-parser": "^3.1.1",
+        "prettier": "1.13.7",
+        "source-map": "^0.5.6",
+        "vue-template-es2015-compiler": "^1.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "consolidate": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
+      "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1"
+      }
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
+    },
+    "css-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
+      "integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "icss-utils": "^2.1.0",
+        "loader-utils": "^1.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "postcss": "^6.0.23",
+        "postcss-modules-extract-imports": "^1.2.0",
+        "postcss-modules-local-by-default": "^1.2.0",
+        "postcss-modules-scope": "^1.1.0",
+        "postcss-modules-values": "^1.3.0",
+        "postcss-value-parser": "^3.3.0",
+        "source-list-map": "^2.0.0"
+      }
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+      "dev": true,
+      "requires": {
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "hash-sum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
+      "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
+      "requires": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      }
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "postcss": {
+      "version": "6.0.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+      "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+      "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+      "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.1",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      }
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "vue": {
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
+      "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ=="
+    },
+    "vue-hot-reload-api": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.1.tgz",
+      "integrity": "sha512-AA86yKZ5uOKz87/q1UpngEXhbRkaYg1b7HMMVRobNV1IVKqZe8oLIzo6iMocVwZXnYitlGwf2k4ZRLOZlS8oPQ==",
+      "dev": true
+    },
+    "vue-loader": {
+      "version": "15.4.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.4.2.tgz",
+      "integrity": "sha512-nVV27GNIA9MeoD8yQ3dkUzwlAaAsWeYSWZHsu/K04KCD339lW0Jv2sJWsjj3721SP7sl2lYdPmjcHgkWQSp5bg==",
+      "dev": true,
+      "requires": {
+        "@vue/component-compiler-utils": "^2.0.0",
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.1.0",
+        "vue-hot-reload-api": "^2.3.0",
+        "vue-style-loader": "^4.1.0"
+      }
+    },
+    "vue-style-loader": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
+      "integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
+      "dev": true,
+      "requires": {
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.0.2"
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
+      "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
+      }
+    },
+    "vue-template-es2015-compiler": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
+      "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/examples/vue-dynamic-import/package.json
+++ b/examples/vue-dynamic-import/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "core-js": "^2.5.7",
     "css-loader": "^1.0.0",
+    "moment": "^2.22.2",
     "vue-loader": "^15.4.2",
     "vue-template-compiler": "^2.5.17"
   }

--- a/examples/vue-dynamic-import/package.json
+++ b/examples/vue-dynamic-import/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "webpack-bable-multi-target-plugin-examples-vue-dynamic-import",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  },
+  "dependencies": {
+    "vue": "^2.5.17"
+  },
+  "devDependencies": {
+    "core-js": "^2.5.7",
+    "css-loader": "^1.0.0",
+    "vue-loader": "^15.4.2",
+    "vue-template-compiler": "^2.5.17"
+  }
+}

--- a/examples/vue-dynamic-import/src/App.vue
+++ b/examples/vue-dynamic-import/src/App.vue
@@ -1,0 +1,25 @@
+<template>
+  <div id="app">
+    <HelloWorld msg="dynamic import"/>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'app',
+  components: {
+    HelloWorld: () => import('./components/HelloWorld.vue')
+  },
+  mounted() {
+    import(/* webpackChunkName: "dep" */ './dependency').then(dep => dep())
+  }
+}
+</script>
+
+<style>
+html,
+body {
+  background: green;
+}
+</style>

--- a/examples/vue-dynamic-import/src/components/HelloWorld.vue
+++ b/examples/vue-dynamic-import/src/components/HelloWorld.vue
@@ -6,6 +6,8 @@
 </template>
 
 <script>
+import moment from 'moment'
+
 export default {
   name: 'HelloWorld',
   props: {
@@ -13,7 +15,8 @@ export default {
   },
   methods: {
     greet() {
-      window.alert(`prop msg: ${this.msg}`)
+      const date = moment().format()
+      window.alert(`prop msg: ${this.msg}, ${date}`)
     }
   },
   mounted() {

--- a/examples/vue-dynamic-import/src/components/HelloWorld.vue
+++ b/examples/vue-dynamic-import/src/components/HelloWorld.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="hello">
+    <h1>{{ msg }}</h1>
+    <button @click="greet">Open alert</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'HelloWorld',
+  props: {
+    msg: String
+  },
+  methods: {
+    greet() {
+      window.alert(`prop msg: ${this.msg}`)
+    }
+  },
+  mounted() {
+    import(/* webpackChunkName: "dep" */ '../dependency').then(dep => dep())
+  }
+}
+</script>
+
+<style>
+.hello {
+  color: white;
+}
+</style>

--- a/examples/vue-dynamic-import/src/dependency.js
+++ b/examples/vue-dynamic-import/src/dependency.js
@@ -1,0 +1,1 @@
+export default () => console.log('dependency!');

--- a/examples/vue-dynamic-import/src/main.js
+++ b/examples/vue-dynamic-import/src/main.js
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import App from './App.vue'
+
+Vue.config.productionTip = false
+
+new Vue({
+  render: h => h(App)
+}).$mount('app-root')

--- a/examples/vue-dynamic-import/webpack.config.js
+++ b/examples/vue-dynamic-import/webpack.config.js
@@ -1,0 +1,45 @@
+const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const BabelMultiTargetPlugin = require('../../').BabelMultiTargetPlugin;
+
+module.exports = {
+    entry: {
+        main: './src/main.js',
+    },
+
+    plugins: [
+        new VueLoaderPlugin(),
+    ],
+
+    module: {
+        rules: [{
+                test: /\.js$/,
+                use: BabelMultiTargetPlugin.loader()
+            }, {
+                test: /\.vue$/,
+                use: [
+                    BabelMultiTargetPlugin.loader('vue-loader'),
+                ]
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    'vue-style-loader',
+                    'css-loader'
+                ]
+            }
+        ],
+    },
+
+    node: {
+      // prevent webpack from injecting useless setImmediate polyfill because Vue
+      // source contains it (although only uses it if it's native).
+      setImmediate: false,
+      // prevent webpack from injecting mocks to Node native modules
+      // that does not make sense for the client
+      dgram: 'empty',
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty',
+      child_process: 'empty'
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-babel-multi-target-plugin",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-babel-multi-target-plugin",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "es6",
     "es7"
   ],
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "author": {
     "name": "Daniel Schaffer",
     "email": "dan@dandoes.net",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "es6",
     "es7"
   ],
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "author": {
     "name": "Daniel Schaffer",
     "email": "dan@dandoes.net",

--- a/src/blind.targeting.error.ts
+++ b/src/blind.targeting.error.ts
@@ -1,0 +1,6 @@
+export class BlindTargetingError extends Error {
+    constructor(request: string) {
+        super(`Encountered unexpected blind targeting request for ${request}.` +
+            'Please see http://github.com/DanielSchaffer/webpack-babel-multi-target-plugin#blind-targeting for more information.');
+    }
+}


### PR DESCRIPTION
With v2.0.0-alpha.3 import of any NPM module can't be resolved and will show an error like the following.

This PR adds an import of momentjs to the `vue-dynamic-import` example to demonstrate this error, but I also was able to reproduce this with e.g. the `es6-plain` example.

```
WARNING in ./src/components/HelloWorld.vue?vue&type=script&lang=js&babel-target=modern (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/babel-loader/lib??ref--3!./node_modules/vue-loader/lib!./src/components/HelloWorld.vue?vue&type=script&lang=js&babel-target=modern) 16:19-25
    "export 'default' (imported as 'moment') was not found in 'moment'
        at HarmonyImportSpecifierDependency._getErrors (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:113:11)
        at HarmonyImportSpecifierDependency.getWarnings (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:60:15)
        at Compilation.reportDependencyErrorsAndWarnings (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/webpack/lib/Compilation.js:1326:24)
        at Compilation.finish (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/webpack/lib/Compilation.js:1137:9)
        at hooks.make.callAsync.err (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/webpack/lib/Compiler.js:545:17)
        at _done (eval at create (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:9:1)
        at _promise1.then._result1 (eval at create (/home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:31:22)
        at <anonymous>
        at process._tickDomainCallback (internal/process/next_tick.js:229:7)
     @ ./src/components/HelloWorld.vue?vue&type=script&lang=js&babel-target=modern
     @ ./src/components/HelloWorld.vue
     @ /home/ranger/workspace/webpack-babel-multi-target-plugin/node_modules/babel-loader/lib??ref--3!./node_modules/vue-loader/lib!./src/App.vue?vue&type=script&lang=js&babel-target=modern
     @ ./src/App.vue?vue&type=script&lang=js&babel-target=modern
     @ ./src/App.vue?babel-target=modern
     @ ./src/main.js?babel-target=modern
```