### PR TITLE
add `cacheDirectory` option for overriding default babel-loader caching

### DIFF
--- a/examples/webpack.common.js
+++ b/examples/webpack.common.js
@@ -97,7 +97,15 @@ module.exports = (workingDir, examples, options = {}) => ({
       template: options.template || '../index.pug',
     }),
 
-    new BabelMultiTargetPlugin({ normalizeModuleIds: true }),
+    new BabelMultiTargetPlugin({
+      normalizeModuleIds: true,
+      // babel: {
+      //   cacheDirectory: false,
+      //   presetOptions: {
+      //     debug: true,
+      //   },
+      // },
+    }),
 
     // new HtmlWebpackIncludeAssetsPlugin({
     //   assets: ['./_shared/include.js'],

--- a/src/babel.multi.target.options.ts
+++ b/src/babel.multi.target.options.ts
@@ -11,6 +11,8 @@ export enum SafariNoModuleFix {
 
 export type SafariNoModuleFixOption = boolean | SafariNoModuleFix
 
+export type BabelLoaderCacheDirectoryOption = boolean | string | ((key: string) => string)
+
 /**
  * Options for configuring {@link BabelMultiTargetPlugin}.
  */
@@ -56,6 +58,11 @@ export interface Options {
      * **IMPORTANT:** `modules` is forced to `false`.
      */
     presetOptions?: BabelPresetOptions
+
+    /**
+     * overrides the default cacheDirectory setting for babel-loader
+     */
+    cacheDirectory?: BabelLoaderCacheDirectoryOption
   }
 
   /**

--- a/src/babel.multi.target.plugin.ts
+++ b/src/babel.multi.target.plugin.ts
@@ -46,7 +46,7 @@ export class BabelMultiTargetPlugin implements Plugin {
     this.targets = Object.keys(options.targets)
       .reduce((result, profileName: BrowserProfileName) => {
         const targetOptions = options.targets[profileName];
-        result.push(targetFactory.createBabelTarget(profileName, targetOptions));
+        result.push(targetFactory.createBabelTarget(profileName, targetOptions, { cacheDirectory: options.babel.cacheDirectory }));
         return result;
       }, []);
 

--- a/src/babel.target.ts
+++ b/src/babel.target.ts
@@ -5,6 +5,7 @@ import ChunkGroup = webpack.compilation.ChunkGroup
 import Entrypoint = webpack.compilation.Entrypoint
 import Module = webpack.compilation.Module
 
+import { BabelLoaderCacheDirectoryOption } from './babel.multi.target.options'
 import { BabelTargetOptions } from './babel.target.options'
 import { BrowserProfileName, StandardBrowserProfileName } from './browser.profile.name'
 import { DEV_SERVER_CLIENT } from './constants'
@@ -196,7 +197,7 @@ export class BabelTargetFactory {
   constructor(private presetOptions: BabelPresetOptions, private plugins: string[]) {
   }
 
-  public createBabelTarget(profileName: BrowserProfileName, options: BabelTargetOptions) {
+  public createBabelTarget(profileName: BrowserProfileName, options: BabelTargetOptions, loaderOptions: { cacheDirectory?: BabelLoaderCacheDirectoryOption } ) {
     const browsers = options.browsers || DEFAULT_BROWSERS[profileName]
     const key = options.key || profileName
 
@@ -208,14 +209,14 @@ export class BabelTargetFactory {
         profileName,
         browsers,
         key,
-        options: this.createTransformOptions(key, browsers),
+        options: this.createTransformOptions(key, browsers, loaderOptions),
       },
     )
 
     return new BabelTarget(info)
   }
 
-  public createTransformOptions(key: string, browsers: string[]): BabelLoaderTransformOptions {
+  public createTransformOptions(key: string, browsers: string[], loaderOptions: { cacheDirectory?: BabelLoaderCacheDirectoryOption }): BabelLoaderTransformOptions {
 
     const mergedPresetOptions: BabelPresetOptions = Object.assign(
       {},
@@ -230,11 +231,9 @@ export class BabelTargetFactory {
       }
     )
 
+    const cacheDirectory = this.getCacheDirectory(key, loaderOptions.cacheDirectory)
+
     return {
-      // ignore: [
-      //     ...STANDARD_IGNORED,
-      //     ...this.options.ignore || [],
-      // ],
       presets: [
         ['@babel/preset-env', mergedPresetOptions],
       ],
@@ -242,8 +241,22 @@ export class BabelTargetFactory {
         ...DEFAULT_BABEL_PLUGINS,
         ...this.plugins,
       ],
-      cacheDirectory: `node_modules/.cache/babel-loader/${key}`,
+      cacheDirectory,
     }
 
+  }
+
+  private getCacheDirectory(key: string, option: BabelLoaderCacheDirectoryOption): string {
+    if (option === false) {
+      return undefined;
+    }
+    if (option === true || typeof option === 'undefined') {
+      return `node_modules/.cache/babel-loader/${key}`
+    }
+    if (typeof option === 'function') {
+      return option(key)
+    }
+
+    return option
   }
 }


### PR DESCRIPTION
fixes #12 