### PR TITLE
save babelTarget in contextInfo to correctly handle commonjs deps

### DIFF
--- a/examples/es6-plain/src/commonjs-five.js
+++ b/examples/es6-plain/src/commonjs-five.js
@@ -1,0 +1,3 @@
+const foo = () => console.log('commonjs 5');
+
+module.exports = foo;

--- a/examples/es6-plain/src/entry.js
+++ b/examples/es6-plain/src/entry.js
@@ -5,6 +5,8 @@ import { makeItGreen } from '../../_shared/make.it.green'
 import { es6 } from '../../_shared/logos'
 import ready from '../../_shared/ready'
 
+require('./commonjs-five');
+
 Promise.all([])
 
 function check(bind = false) {

--- a/src/targeting.plugin.ts
+++ b/src/targeting.plugin.ts
@@ -177,6 +177,9 @@ export class TargetingPlugin implements Plugin {
 
     let babelTarget = BabelTarget.getTargetFromTag(resolveContext.request, this.targets)
     if (babelTarget) {
+      // save babelTarget for quick lookup
+      // makes it easier to get babelTarget for commonjs modules.
+      resolveContext.contextInfo = { babelTarget }
       this.targetChunkNames(resolveContext, babelTarget)
       return
     }


### PR DESCRIPTION
Thanks for creating and maintaining this very useful plugin!

We came across following issue: 
When a modern js is `required` instead of `imported`, it is not transpiled with babel in the legacy bundle. Please check the modified example in the PR. Without the code change, `commonjs-five.js` is included as it is in the legacy bundle at `es6-plain/main.js`.

Code [here](https://github.com/DanielSchaffer/webpack-babel-multi-target-plugin/blob/845cfd2e59df20d472065d0a723597d24e6480dd/src/targeting.plugin.ts#L344) looks for field only available in ES6 modules while computing the targets, so commonjs modules are left out. As an earlier line looks for `conrtextInfo.babelTarget` we can put `babelTarget` there.

As per the example, it appears to be working. Please let me know if there is a better way to handle this scenario.