### PR TITLE
Adjust example to cause normalize css issue

### DIFF
--- a/examples/es6-dynamic-import/src/entry.js
+++ b/examples/es6-dynamic-import/src/entry.js
@@ -16,24 +16,13 @@ function check(bind = false) {
     document.onreadystatechange = check.bind(null, false)
   }
 }
-
-function importPluginByExpression(plugin) {
-  return import(`./plugins/${plugin}/plugin.js`)
-}
-
-function loadPlugin() {
-  const pluginMatch = window.location.search.match(/\bplugin=([ab])\b/)
-  const plugin = pluginMatch ? pluginMatch[1] : 'a'
-  return importPluginByExpression(plugin)
-}
-
 async function init() {
   const dom = createDom('es6-dynamic-import', es6)
 
   const greener = await import('../../_shared/make.it.green')
   greener.makeItGreen()
 
-  await loadPlugin()
+  await import('./loader.js').loadPlugin()
 
   dom.setStatus(GTG)
   ready()

--- a/examples/es6-dynamic-import/src/loader.js
+++ b/examples/es6-dynamic-import/src/loader.js
@@ -1,0 +1,9 @@
+function importPluginByExpression(plugin) {
+    return import(`./plugins/${plugin}/plugin.js`)
+}
+
+export function loadPlugin() {
+    const pluginMatch = window.location.search.match(/\bplugin=([ab])\b/)
+    const plugin = pluginMatch ? pluginMatch[1] : 'a'
+    return importPluginByExpression(plugin)
+}


### PR DESCRIPTION
@DanielSchaffer Here's the adjustments to reproduce the issue #23, sorry if my code in original example didn't quite indicate that this issue only occurs when doing an epxression-dynamic-import *inside* another dynamic import.

What I did:
- create loader.js file which loads the expressions and exposes "loadPlugin" function
- import('./loader.js') from "entry.js"
