### PR TITLE
Fix bug in exclusion logic

### DIFF
--- a/src/targeting.plugin.ts
+++ b/src/targeting.plugin.ts
@@ -350,7 +350,7 @@ export class TargetingPlugin implements Plugin {
       return false
     }
 
-    if (this.exclude.find(pattern => pattern.test(resolveContext.resolve))) {
+    if (this.exclude.find(pattern => pattern.test(resolveContext.resource))) {
       // TODO: report this somewhere?
       // console.info('not transpiling request from excluded patterns', resolveContext.resource)
       return false


### PR DESCRIPTION
Exclusion does not work using webpack `4.40.2`, since `resolveContext.resolve` is undefined. It seems like the intent was to target `resolveContext.resource`, as per the default excludes in the lines above.