### PR TITLE
fix: Add exclude for 'querystring-es3'

### DIFF
--- a/src/excluded.packages.ts
+++ b/src/excluded.packages.ts
@@ -20,6 +20,7 @@ export const STANDARD_EXCLUDED = [
   // webpack dev server
   excludeNodeModulesPackage('webpack-dev-server'),
   excludeNodeModulesPackage('\\(webpack\\)-dev-server'),
+  excludeNodeModulesPackage('querystring-es3'),
 
   // polyfills
   excludeNodeModulesPackage('@babel', 'runtime'),


### PR DESCRIPTION
- This is used by 'webpack-dev-server' and results in a runtime error if transpiled.

Fixes #61