### PR TITLE
fix: check for entryPoint to have entryModule

### DIFF
--- a/examples/typescript-plain/webpack.config.js
+++ b/examples/typescript-plain/webpack.config.js
@@ -15,6 +15,10 @@ module.exports = {
     'main': './src/entry.ts',
   },
 
+  optimization: {
+    runtimeChunk: 'single',
+  },
+
   module: {
     rules: [
       {

--- a/src/babel-target.ts
+++ b/src/babel-target.ts
@@ -162,6 +162,9 @@ export class BabelTarget implements BabelTargetInfo {
   }
 
   public static getTargetFromEntrypoint(entrypoint: Entrypoint): BabelTarget {
+    if (!entrypoint.runtimeChunk.hasEntryModule()) {
+      return undefined
+    }
     return BabelTarget.getTargetFromModule(entrypoint.runtimeChunk.entryModule)
   }
 

--- a/src/babel.multi.target.html.updater.ts
+++ b/src/babel.multi.target.html.updater.ts
@@ -46,6 +46,10 @@ export class BabelMultiTargetHtmlUpdater implements Plugin {
         }
 
         const target = targets[0]
+        if (target === undefined) {
+          return
+        }
+
         if (target.esModule) {
           tag.attributes.type = 'module'
           return


### PR DESCRIPTION
fixes #56

I'm also suggesting enable strict mode or just strictNullCheck to avoid similar problems.